### PR TITLE
Make the app usable in both Mac and Win

### DIFF
--- a/HardCoverBookAwsCommandGenerator/Program.cs
+++ b/HardCoverBookAwsCommandGenerator/Program.cs
@@ -35,12 +35,9 @@ while (String.IsNullOrEmpty(environment))
 }
 
 Console.WriteLine($"Generating the commands for environment: {environment}");
+
 Console.WriteLine($"** Input Json ** {Environment.NewLine}");
-
 string jsonData = Console.ReadLine();
-
-
-// 
 
 // Generate S3 get object command
 PdfGenEvent inputJsonObject = PdfGenEvent.GetJsonObject(jsonData);


### PR DESCRIPTION
# Summary
- Used `Path.Combine()` to get appropriate path formats per OS.
- AWS CLI doesn't accept empty space in the path. If windows machine has OneDrive, then chancer are there could a folder with empty space in the name. To prevent that I changed the root directory to current user profile.